### PR TITLE
updates signature url

### DIFF
--- a/docs/04-onboarding/first-day.md
+++ b/docs/04-onboarding/first-day.md
@@ -36,7 +36,7 @@ need a lot of technology experience!
   * Managers and mentors will send meeting invites to your account before your
   first day. You should check if anyone has sent you one and accept.
 * Set up your Bixal Signature at
-[Bixal Signature Generator](https://bixal-signature.herokuapp.com/)
+[Bixal Signature Generator](https://signature.bixal.com/)
   * There are additional links on that page with additional instructions!
 * Change your default meeting duration to allow for time between meetings
   * Review [A Better Meeting Culture](https://techbook.bixal.com)


### PR DESCRIPTION
This request updates the link for the "Bixal Signature Generator" to its new location @ **signature.bixal.com**

We have moved the signature application from https://bixal-signature.herokuapp.com/ to AWS with the subdomain signature.bixal.com that points to this new s3 bucket.  We will be sunsetting the Heroku application once documentation in the appropriate departments have all been updated.